### PR TITLE
FIX: tensorflow version must be lower than 2.0

### DIFF
--- a/bertserving/Dockerfile
+++ b/bertserving/Dockerfile
@@ -1,6 +1,6 @@
-FROM python:3
+FROM tensorflow/tensorflow:1.12.0-py3
 RUN pip install -U pip
-RUN pip install --no-cache-dir tensorflow bert-serving-server
+RUN pip install --no-cache-dir bert-serving-server
 COPY ./ /app
 COPY ./entrypoint.sh /app
 WORKDIR /app


### PR DESCRIPTION
otherwise bert-as-service does not work.

The problem is here in bert as service. https://github.com/hanxiao/bert-as-service/blob/master/server/bert_serving/server/helper.py#L184. 

Essentially `tf.logging` no longer exists from tensorflow 2.0 onwards. [source](https://www.tensorflow.org/guide/effective_tf2)


Here, I pinned the starting image to same as stated in bert as service. Here is their [dockerfile](https://github.com/hanxiao/bert-as-service/blob/master/docker/Dockerfile). Alternatively, we could probably fix the version of tensorflow in the pip install line.
