### PR TITLE
Fix BERT version on pip install

### DIFF
--- a/bertserving/Dockerfile
+++ b/bertserving/Dockerfile
@@ -1,6 +1,6 @@
 FROM tensorflow/tensorflow:1.12.0-py3
 RUN pip install -U pip
-RUN pip install --no-cache-dir bert-serving-server
+RUN pip install --no-cache-dir bert-serving-server==1.9.8
 COPY ./ /app
 COPY ./entrypoint.sh /app
 WORKDIR /app


### PR DESCRIPTION
web_1            | [2019-11-26 19:26:34,362] ERROR in app: Exception on /search [GET]
web_1            | Traceback (most recent call last):
web_1            |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 2446, in wsgi_app
web_1            |     response = self.full_dispatch_request()
web_1            |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1951, in full_dispatch_request
web_1            |     rv = self.handle_user_exception(e)
web_1            |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1820, in handle_user_exception
web_1            |     reraise(exc_type, exc_value, tb)
web_1            |   File "/usr/local/lib/python3.8/site-packages/flask/_compat.py", line 39, in reraise
web_1            |     raise value
web_1            |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1949, in full_dispatch_request
web_1            |     rv = self.dispatch_request()
web_1            |   File "/usr/local/lib/python3.8/site-packages/flask/app.py", line 1935, in dispatch_request
web_1            |     return self.view_functions[rule.endpoint](**req.view_args)
web_1            |   File "app.py", line 19, in analyzer
web_1            |     bc = BertClient(ip='bertserving', output_fmt='list')
web_1            |   File "/usr/local/lib/python3.8/site-packages/bert_serving/client/__init__.py", line 111, in __init__
web_1            |     raise AttributeError('version mismatch! server version is %s but client version is %s!\n'
web_1            | AttributeError: version mismatch! server version is 1.9.9 but client version is 1.9.8!
web_1            | consider "pip install -U bert-serving-server bert-serving-client"
web_1            | or disable version-check by "BertClient(check_version=False)"
web_1            | 128.224.222.42 - - [26/Nov/2019 19:26:34] "GET /search?q=designer HTTP/1.1" 500 -
