### PR TITLE
Specify bert-serving-server version

### DIFF
--- a/bertserving/Dockerfile
+++ b/bertserving/Dockerfile
@@ -1,6 +1,6 @@
 FROM tensorflow/tensorflow:1.12.0-py3
 RUN pip install -U pip
-RUN pip install --no-cache-dir bert-serving-server
+RUN pip install --no-cache-dir bert-serving-server==1.9.8
 COPY ./ /app
 COPY ./entrypoint.sh /app
 WORKDIR /app


### PR DESCRIPTION
Since new bert-serving versions have been released, address server/client version mismatch errors by installing the bert-serving-server version that matches the bert-serving-client version specified in 'example/requirements.txt'